### PR TITLE
Adds privacy manifest in resource bundles

### DIFF
--- a/SweeterSwift.podspec
+++ b/SweeterSwift.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/yonat/SweeterSwift.git", :tag => s.version }
   s.source_files  = "Source/*.swift"
-  s.resources = ['PrivacyInfo.xcprivacy']
+  s.resource_bundles = { 'SweeterSwift' => '*.xcprivacy' }
 
 end

--- a/SweeterSwift.podspec
+++ b/SweeterSwift.podspec
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
 
   s.source       = { :git => "https://github.com/yonat/SweeterSwift.git", :tag => s.version }
   s.source_files  = "Source/*.swift"
-  s.resource_bundles = { 'SweeterSwift' => '*.xcprivacy' }
+  s.resource_bundles = {'SweeterSwift' => ['PrivacyInfo.xcprivacy']}
 
 end


### PR DESCRIPTION
Hi! 
We were hitting some issues with our release, and I think it might caused by the privacy manifests being added to the resources instead of the bundled resources.

This change moves the privacy manifest into its own bundle, as the "copy pods resources" script from cocoapods would cause collisions when the main target includes a "PrivacyInfo.xcprivacy" itself.

Same logic added by other SDK: https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/pull/1376/files