### PR TITLE
Fix the path of PrivacyInfo.xcprivacy

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [],
     targets: [
-        .target(name: "SweeterSwift", dependencies: [], path: "Source", resources: [.copy("PrivacyInfo.xcprivacy")]),
+        .target(name: "SweeterSwift", dependencies: [], path: "Source", resources: [.copy("../PrivacyInfo.xcprivacy")]),
         .testTarget(name: "SweeterSwiftTests", dependencies: ["SweeterSwift"], path: "SweeterSwift/SweeterSwiftTests"),
     ],
     swiftLanguageVersions: [.v5]


### PR DESCRIPTION
# Context

- Our team is using `Tuist` for Workspace configuration. When adding `MultiSlider`, which uses `SweeterSwift`, we discovered an issue where the `PrivacyInfo.xcprivacy` file wasn't being added due to an incorrect path specification. 
- This resulted in a warning that `Source/PrivacyInfo.xcprivacy couldn't be found` during workspace configuration.
- As shown in this PR, I found that the file was properly included. It would be great if you could apply this fix to `MultiSlider` as well! (version update)

# Patch

- Fix the path of `PrivacyInfo.xcprivacy` in `Package.swift`

# Screenshot (after patch)

<img width="400" alt="privacy path" src="https://github.com/user-attachments/assets/5fc91088-4206-40f9-bf73-72936f6f50e7">
